### PR TITLE
Add agent framework acceptance tests

### DIFF
--- a/deployment-config/README.md
+++ b/deployment-config/README.md
@@ -9,6 +9,8 @@ deployment-config/
 ├── environment-config.yaml           # 环境管理配置
 ├── architecture-compliance.yaml      # 架构合规检查
 ├── validation-checklist.yaml        # 验证清单
+├── agent-framework-intent.yaml      # Agent框架部署意图
+├── agent-framework-test.yaml        # Agent框架验收测试
 ├── DEPLOYMENT-GUIDE.md              # 详细部署指南
 └── scripts/                         # 支持脚本
     ├── auto_review.sh               # 自动代码审查
@@ -58,7 +60,22 @@ deployment-config/
   - 安全性检查
 - **使用**: 部署质量保证
 
-#### 5. `DEPLOYMENT-GUIDE.md`
+#### 5. `agent-framework-intent.yaml`
+- **作用**: Agent框架部署计划
+- **内容**:
+  - Flowise、CrewAI、LangGraph 部署命令
+  - 关键组件和扩展建议
+- **使用**: 选择框架并规划部署
+
+#### 6. `agent-framework-test.yaml`
+- **作用**: Agent框架验收测试
+- **内容**:
+  - 环境预检查
+  - 单框架功能测试
+  - 集成验证
+- **使用**: 部署完成后的质量确认
+
+#### 7. `DEPLOYMENT-GUIDE.md`
 - **作用**: 详细部署指南
 - **内容**:
   - 完整的部署流程说明

--- a/deployment-config/agent-framework-intent.yaml
+++ b/deployment-config/agent-framework-intent.yaml
@@ -1,0 +1,90 @@
+# Agent Framework Intent Spec
+# 面向 Flowise v3 / CrewAI 0.14 / LangGraph 0.5 的部署意图说明
+
+metadata:
+  name: "agent-framework-intent"
+  version: "1.0.0"
+  description: "基于三大热门Agent框架的统一部署计划"
+  created_date: "2025-07-22"
+
+# 目标概述
+objectives:
+  - "两小时内跑通最小部署"
+  - "官方Docker Compose示例"
+  - "后续可扩展为企业级工作流"
+
+# 框架选择
+frameworks:
+  - name: "Flowise"
+    version: "3.0.2"
+    role: "快速POC和拖拽式设计"
+    deploy:
+      method: "docker"
+      command: "docker run -d --name flowise -p 3000:3000 -e 'FLOWISE_USERNAME=admin' -e 'FLOWISE_PASSWORD=1234' flowiseai/flowise:3.0.2"
+  - name: "CrewAI"
+    version: "0.140.0"
+    role: "多Agent任务编排"
+    deploy:
+      method: "pip"
+      command: |
+        pip install crewai==0.140.0
+        crewai init
+        crewai run pipeline.yml
+  - name: "LangGraph"
+    version: "0.5"
+    role: "复杂控制与企业级扩展"
+    deploy:
+      method: "pip"
+      command: |
+        pip install langgraph[all]
+        python demo_graph.py
+
+# 关键组件
+components:
+  flowise:
+    features:
+      - RAG
+      - AgentFlow
+      - Webhook
+      - JWT登录
+  crewai:
+    features:
+      - 任务/Agent/工具分层
+      - Guardrail
+      - YAML Pipeline
+      - Tracing
+  langgraph:
+    features:
+      - 状态持久化
+      - 循环与分支控制
+      - LangSmith监控
+
+# 部署步骤
+steps:
+  - id: "STEP-1"
+    name: "准备环境"
+    tasks:
+      - "安装 Docker 及 Compose"
+      - "安装 Python 3.10+"
+  - id: "STEP-2"
+    name: "启动 Flowise"
+    run: "{{frameworks[0].deploy.command}}"
+  - id: "STEP-3"
+    name: "初始化 CrewAI"
+    run: "{{frameworks[1].deploy.command}}"
+  - id: "STEP-4"
+    name: "运行 LangGraph 示例"
+    run: "{{frameworks[2].deploy.command}}"
+  - id: "STEP-5"
+    name: "验证功能"
+    tasks:
+      - "确保 Flowise UI 可访问"
+      - "CrewAI pipeline 正常执行"
+      - "LangGraph 示例输出正确"
+
+# 扩展建议
+extensions:
+  - "将 Flowise 流程保存为 JSON 版本控制"
+  - "在 CrewAI 中定义 YAML pipeline 以便团队协作"
+  - "使用 LangGraph 处理并发与复杂回溯需求"
+

--- a/deployment-config/agent-framework-test.yaml
+++ b/deployment-config/agent-framework-test.yaml
@@ -1,0 +1,65 @@
+# Agent Framework Acceptance Test Spec
+# 针对 Flowise v3 / CrewAI 0.14 / LangGraph 0.5 的验收测试清单
+
+metadata:
+  name: "agent-framework-validation"
+  version: "1.0.0"
+  description: "三大框架部署后的功能与稳定性验收"
+  created_date: "2025-07-22"
+
+pre_checks:
+  - id: "PRE-001"
+    category: "environment"
+    priority: "critical"
+    name: "Docker 服务检查"
+    command: "docker info"
+    expected: "return code 0"
+    status: "pending"
+
+  - id: "PRE-002"
+    category: "environment"
+    priority: "high"
+    name: "Python 版本 >= 3.10"
+    command: "python3 --version"
+    expected: "Python 3.10+"
+    status: "pending"
+
+tests:
+  flowise:
+    - id: "FLOW-001"
+      name: "Flowise 容器运行"
+      command: "docker ps | grep flowise"
+      expected: "容器状态为 Up"
+      status: "pending"
+    - id: "FLOW-002"
+      name: "Flowise UI 可访问"
+      command: "curl -s -o /dev/null -w '%{http_code}' http://localhost:3000"
+      expected: "200"
+      status: "pending"
+
+  crewai:
+    - id: "CREW-001"
+      name: "CrewAI pipeline 执行"
+      command: "crewai run pipeline.yml"
+      expected: "Finished successfully"
+      status: "pending"
+
+  langgraph:
+    - id: "GRAPH-001"
+      name: "LangGraph demo 执行"
+      command: "python demo_graph.py"
+      expected: "Workflow completed"
+      status: "pending"
+
+integration_tests:
+  - id: "INT-001"
+    name: "Flowise 调用 CrewAI 工具链"
+    command: "curl -X POST http://localhost:3000/api/trigger -d '{\"task\":\"test\"}'"
+    expected: "200"
+    status: "pending"
+  - id: "INT-002"
+    name: "CrewAI 调用 LangGraph 服务"
+    command: "python crew_to_graph.py"
+    expected: "Success"
+    status: "pending"
+


### PR DESCRIPTION
## Summary
- add `agent-framework-test.yaml` defining pre-checks and integration tests
- reference new YAML files in `deployment-config/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687fa52090988333a1da4f519f57889b